### PR TITLE
update link of frantic1048

### DIFF
--- a/about/friends.rst
+++ b/about/friends.rst
@@ -67,7 +67,7 @@
 
 .. friend:: frantic1048
             卡夫
-   :blog: http://frantic1048.logdown.com/
+   :blog: https://pyonpyon.today/
    :avatar: https://github.com/frantic1048.png
 
    - 萌萌的现代前端魔法师


### PR DESCRIPTION
Old site http://frantic1048.logdown.com/ was deprecated.
It's a readonly site and frantic1048 has no way to access its content.

Logdown's github application has been suspended for a long time.
And their support(http://help.logdown.com/) shows "This site is closed.".
As a result, frantic1048 can no longer login to the site. qaq